### PR TITLE
Update TP-Link EnergyMonitor Plug.groovy

### DIFF
--- a/Device Handlers/TP-Link EnergyMonitor Plug.groovy
+++ b/Device Handlers/TP-Link EnergyMonitor Plug.groovy
@@ -409,7 +409,7 @@ def currentDateResponse(cmdResponse) {
 //	----- SEND COMMAND TO CLOUD VIA SM -----
 private sendCmdtoServer(command, hubCommand, action) {
 	try {
-		if (installType() == "Cloud") {
+		if (install_Type == "Kasa Account") {
 			sendCmdtoCloud(command, hubCommand, action)
 		} else {
 			sendCmdtoHub(command, hubCommand, action)


### PR DESCRIPTION
Correcting to install_type variable and Kasa Account reference to correct GroovyRuntimeException: Cannot read write-only property: installType